### PR TITLE
Add env examples and improve setup docs

### DIFF
--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -1,0 +1,13 @@
+# Django
+SECRET_KEY=replace-with-a-local-development-secret
+
+# PostgreSQL
+DATABASE_URL=postgresql://username:password@localhost:5432/aggieagenda
+
+# Google OAuth
+GOOGLE_CLIENT_ID=replace-with-google-client-id.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=replace-with-google-client-secret
+
+# Supabase
+SUPABASE_URL=https://your-project-ref.supabase.co
+SUPABASE_ANON_KEY=replace-with-supabase-anon-key

--- a/Backend/README.md
+++ b/Backend/README.md
@@ -1,6 +1,46 @@
-How to run backend
-1. Make virtual environment and get all requirements in requirements.txt
-- pip install requirements.txt
-- CD in to backend and use python manage.py runserver to get the server running locally
-- make the .env variable with the keys in this directory next to manage.py 
-- python manage.py runserver
+# Aggie Agenda Backend
+
+The backend is a Django and Django REST Framework API.
+
+## Prerequisites
+
+- Python 3.10 or higher
+- PostgreSQL database URL
+- Google OAuth credentials
+- Supabase project URL and anon key
+
+## Setup
+
+From the repository root:
+
+```bash
+cd Backend
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env
+```
+
+Fill in the required values in `.env`:
+
+- `SECRET_KEY`
+- `DATABASE_URL`
+- `GOOGLE_CLIENT_ID`
+- `GOOGLE_CLIENT_SECRET`
+- `SUPABASE_URL`
+- `SUPABASE_ANON_KEY`
+
+Then run migrations and start the server:
+
+```bash
+python manage.py migrate
+python manage.py runserver
+```
+
+The backend runs at `http://localhost:8000` by default.
+
+## Validation
+
+```bash
+python manage.py check
+```

--- a/Frontend/.env.example
+++ b/Frontend/.env.example
@@ -1,0 +1,2 @@
+VITE_BACKEND_URL=http://localhost:8000
+VITE_GOOGLE_CLIENT_ID=replace-with-google-client-id.apps.googleusercontent.com

--- a/Frontend/README.md
+++ b/Frontend/README.md
@@ -1,12 +1,39 @@
-# React + Vite
+# Aggie Agenda Frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+The frontend is a React app built with Vite.
 
-Currently, two official plugins are available:
+## Prerequisites
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- Node.js
+- npm
+- Backend running locally at `http://localhost:8000`
+- Google OAuth client ID
 
-## Expanding the ESLint configuration
+## Setup
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+From the repository root:
+
+```bash
+cd Frontend
+npm install
+cp .env.example .env
+```
+
+Fill in the required values in `.env`:
+
+- `VITE_BACKEND_URL`
+- `VITE_GOOGLE_CLIENT_ID`
+
+Start the development server:
+
+```bash
+npm run dev
+```
+
+The frontend runs at `http://localhost:5173` by default.
+
+## Validation
+
+```bash
+npm run build
+```

--- a/README.md
+++ b/README.md
@@ -39,40 +39,36 @@ App/
 - Node.js and npm
 - [Google Calendar API credentials](https://developers.google.com/calendar/quickstart/js)
 
-### Backend Setup
+### Local Development
+
+Run the backend and frontend in separate terminals.
+
+Backend setup:
+
+- Environment example: [Backend/.env.example](Backend/.env.example)
+- Setup docs: [Backend/README.md](Backend/README.md)
 
 ```bash
-# Navigate to backend directory
-cd App/Backend
-
-# Create and activate virtual environment
-python -m venv ../app_env
-source ../app_env/bin/activate  # Mac/Linux
-# or
-../app_env/Scripts/activate     # Windows
-
-# Install dependencies
+cd Backend
+python -m venv .venv
+source .venv/bin/activate
 pip install -r requirements.txt
-
-# Configure environment variables
-# Create a .env file in the Backend directory with your credentials
-
-# Start the server
+cp .env.example .env
+python manage.py migrate
 python manage.py runserver
 ```
 
 The backend will run on `http://localhost:8000`
 
-### Frontend Setup
+Frontend setup:
+
+- Environment example: [Frontend/.env.example](Frontend/.env.example)
+- Setup docs: [Frontend/README.md](Frontend/README.md)
 
 ```bash
-# Navigate to frontend directory
-cd App/Frontend
-
-# Install dependencies
+cd Frontend
 npm install
-
-# Start development server
+cp .env.example .env
 npm run dev
 ```
 


### PR DESCRIPTION
## Summary
- Add backend and frontend `.env.example` files with safe placeholder values
- Replace default/incomplete setup docs with app-specific backend and frontend instructions
- Update the root README with concise local development steps and links to setup docs

## Validation
- `git diff --check`

## Notes
- Did not run backend checks because Django is not installed in the active Python environment.
- Did not run the frontend build because local `node_modules` is missing `react-ga4`.